### PR TITLE
[update]自動生産で1秒毎にnクッキーを瞬間的に増やしていた処理を、毎フレーム(n*前フレームからの経過時間[s])クッキー生産する…

### DIFF
--- a/Assets/Scripts/Player/CookieGenerator.cs
+++ b/Assets/Scripts/Player/CookieGenerator.cs
@@ -1,21 +1,32 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
+using System.Text;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using TeamD.Enum;
+using UniRx;
 using UnityEngine;
 
 public class CookieGenerator : MonoBehaviour
 {
+    [SerializeField, Tooltip("デバッグログ表示")] bool _activeDebugLog = true;
     private const int GoldenCookieAddValue = 7;
     private readonly PlayerManager _playerManager = PlayerManager.Instance;
     Factories _factories;
+    FloatReactiveProperty _currentCpS = new();
 
     private void Start()
     {
         _factories = Resources.Load<Factories>("Excel/Factories");
         var ct = this.GetCancellationTokenOnDestroy();
         AutoGenerate(ct).Forget();
+        _currentCpS.SkipLatestValueOnSubscribe().Subscribe(_=>CurrentCpSView()).AddTo(this);
+    }
+
+    private void CurrentCpSView()
+    {
+        if (!_activeDebugLog) return;
+        StringBuilder sb = new StringBuilder().Append("現在のCpS: ").Append(_currentCpS.Value);
+        print(sb.ToString());
     }
 
     // TODO 一応自動用と手動用で分けているが、統一出来そうな気もする
@@ -29,20 +40,18 @@ public class CookieGenerator : MonoBehaviour
         {
             if (_playerManager.IsGoldenCookieMode)
             {
-                _playerManager.AddCookie(StatsManager.FactoryStats
-                    .Select(x => _factories.Entities
-                        .Find(e => e.Key == x.Key).CpS * x.Value.Amount * (1 << (int)x.Value.Tier))
-                    .Sum() * GoldenCookieAddValue);
+                var cps = StatsManager.CpS * GoldenCookieAddValue;
+                _currentCpS.Value = (float)cps;
+                _playerManager.AddCookie(cps * Time.deltaTime);
             }
             else
             {
-                _playerManager.AddCookie(StatsManager.FactoryStats
-                    .Select(x => _factories.Entities
-                        .Find(e => e.Key == x.Key).CpS * x.Value.Amount * (1 << (int)x.Value.Tier))
-                    .Sum());
+                var cps = StatsManager.CpS;
+                _currentCpS.Value = (float)cps;
+                _playerManager.AddCookie(cps * Time.deltaTime);
             }
-
-            await UniTask.Delay(TimeSpan.FromSeconds(1), cancellationToken: ct);
+            //  Updateメソッドと同じ周期
+            await UniTask.Yield(cancellationToken: ct);
         }
     }
 

--- a/Assets/Scripts/Shop/Shop.cs
+++ b/Assets/Scripts/Shop/Shop.cs
@@ -18,16 +18,12 @@ public class Shop : MonoBehaviour
     float _sellFactoryRatio = 2f / 3f;
 
     Factories _factories;
-    Tiers _tiers;
-    Upgrades _upgrades;
 
     List<ShopItemButton> _currentButtons = new();
 
     private void Start()
     {
         _factories = Resources.Load<Factories>("Excel/Factories");
-        _tiers = Resources.Load<Tiers>("Excel/Tiers");
-        _upgrades = Resources.Load<Upgrades>("Excel/Upgrades");
         
         foreach (var factory in _factories.Entities)
         {   
@@ -67,36 +63,31 @@ public class Shop : MonoBehaviour
                 }
             };
         }
-        StatsManager.FactoryStats.ObserveReplace().Subscribe(_=> GenerateUpgradeShop()).AddTo(this);
+        StatsManager.OnUpdateNextUpgrades.Subscribe(GenerateUpgradeShop).AddTo(this);
     }
 
-    void GenerateUpgradeShop()
+    void GenerateUpgradeShop(Dictionary<FactoriesEntity, (TiersEntity Tier, UpgradesEntity UpgradesInfo)> nextUpgrades)
     {
         _currentButtons?.ForEach(b=>Destroy(b.gameObject));
         _currentButtons?.Clear();
-        foreach (var pair in StatsManager.FactoryStats)
+        foreach (var nextUpgrade in nextUpgrades)
         {
-            var topTier = _tiers.Entities.FirstOrDefault(x => x.Tier == pair.Value.Tier + 1);
-            if(topTier == null) continue;
-            if (topTier.Condition <= pair.Value.Amount)
+            var button = Instantiate(_shopItemButtonPrefab, _upgradeButtonParent).GetComponent<ShopItemButton>();
+            _currentButtons.Add(button);
+            var price = nextUpgrade.Key.BasePrice * nextUpgrade.Value.Tier.Multiplier;
+            button.SetItemName(nextUpgrade.Value.UpgradesInfo.Name, false);
+            button.SetPriceText(price);
+            button.OnLeftClickEvent += () =>
             {
-                var button = Instantiate(_shopItemButtonPrefab, _upgradeButtonParent).GetComponent<ShopItemButton>();
-                _currentButtons.Add(button);
-                var price = _factories.Entities.Find(x => x.Key == pair.Key).BasePrice * topTier.Multiplier;
-                button.SetItemName(_upgrades.Entities.Find(x=>x.Key.Equals(pair.Key) && x.Tier.Equals(topTier.Tier)).Name, false);
-                button.SetPriceText(price);
-                button.OnLeftClickEvent += () =>
+                if (price <= PlayerManager.Instance.CookieCount)
                 {
-                    if (price <= PlayerManager.Instance.CookieCount)
-                    {
-                        var factoryStat = StatsManager.FactoryStats[pair.Key];
-                        factoryStat.Tier += 1;
-                        StatsManager.FactoryStats[pair.Key] = factoryStat;
-                        PlayerManager.Instance.SubtractCookie(price);
-                        Destroy(button.gameObject);
-                    }
-                };
-            }
+                    var factoryStat = StatsManager.FactoryStats[nextUpgrade.Key.Key];
+                    factoryStat.Tier += 1;
+                    StatsManager.FactoryStats[nextUpgrade.Key.Key] = factoryStat;
+                    PlayerManager.Instance.SubtractCookie(price);
+                    Destroy(button.gameObject);
+                }
+            };
         }
     }
 }

--- a/Assets/WorkSpace/Takechi/StatsManager.cs
+++ b/Assets/WorkSpace/Takechi/StatsManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TeamD.Enum;
@@ -17,10 +18,46 @@ public static class StatsManager
     /// <summary>施設のアップグレード状況と数</summary>
     public static ReactiveDictionary<FactoryKey, (UpgradeTier Tier, int Amount)> FactoryStats { get; set; }
 
+    /// <summary>購入可能なアップグレードのディクショナリ</summary>
+    static Dictionary<FactoriesEntity, (TiersEntity Tier, UpgradesEntity UpgradesInfo)> _nextUpgrades = new();
+    public static Subject<Dictionary<FactoriesEntity, (TiersEntity Tier, UpgradesEntity UpgradesInfo)>> OnUpdateNextUpgrades { get; } = new();
+    /// <summary>Cookie Per Seconds: 一秒間に生成するクッキー数</summary>
+    public static double CpS { get; private set; }
+
+    static Factories _factories;
+    static Tiers _tiers;
+    static Upgrades _upgrades;
+
+    static void UpdateCpS()
+    {
+        CpS = FactoryStats.Select(x => _factories.Entities
+            .Find(e => e.Key == x.Key).CpS * x.Value.Amount * (1 << (int)x.Value.Tier)).Sum();
+    }
+
+    static void UpdateNextUpgrades()
+    {
+        _nextUpgrades.Clear();
+        foreach (var pair in FactoryStats)
+        {
+            var nextTier = _tiers.Entities.FirstOrDefault(x => x.Tier == pair.Value.Tier + 1);
+            if (nextTier == null) continue;
+            if (nextTier.Condition <= pair.Value.Amount)
+            {
+                _nextUpgrades.Add(_factories.Entities
+                    .First(e=>e.Key.Equals(pair.Key)), (nextTier, _upgrades.Entities
+                    .FirstOrDefault(e=>e.Key.Equals(pair.Key) && e.Tier.Equals(nextTier.Tier))));
+            }
+        }
+        OnUpdateNextUpgrades.OnNext(_nextUpgrades);
+    }
     static StatsManager()
     {
-        var factories = Resources.Load<Factories>("Excel/Factories");
-        FactoryStats = factories.Entities.ToDictionary(entity=>entity.Key, _=>(UpgradeTier.NoUpgrade, 0))
+        _factories = Resources.Load<Factories>("Excel/Factories");
+        _tiers = Resources.Load<Tiers>("Excel/Tiers");
+        _upgrades = Resources.Load<Upgrades>("Excel/Upgrades");
+        FactoryStats = _factories.Entities.ToDictionary(entity=>entity.Key, _=>(UpgradeTier.NoUpgrade, 0))
             .ToReactiveDictionary();
+        FactoryStats.ObserveReplace().Subscribe(_ => UpdateCpS());
+        FactoryStats.ObserveReplace().Subscribe(_ => UpdateNextUpgrades());
     }
 }


### PR DESCRIPTION
…処理に変更した。

[update]自動生産する際に毎回その場で加算量を計算していた処理を中止し、StatsManagerで予め加算量を計算しておき、その数値を利用してクッキーを加算する処理に移行した。